### PR TITLE
Organizing Devplat

### DIFF
--- a/docs.hpcloud.com.ditamap
+++ b/docs.hpcloud.com.ditamap
@@ -251,232 +251,460 @@
  <!--permalink: /helion/community/troubleshooting/--> <topicref href="community/community.troubleshoot.dita"/> 
  <!--permalink: /helion/community/verify/--> <topicref href="community/community.verify.dita"/> 
  <!--permalink: /helion/devplatform/--> <topicref href="devplatform/1.0devplatform.index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/--> <topicref href="devplatform/1.1devplatform.index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/3rd-party-license-agreements/--> <topicref href="devplatform/1.1devplatform.thirdparty.licensing.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/--> <topicref href="devplatform/helion/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/--> <topicref href="devplatform/helion/admin/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/best-practices/--> <topicref href="devplatform/helion/admin/best-practices/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/best-practices/logging-examples/--> <topicref href="devplatform/helion/admin/best-practices/1.1logging-examples.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/cluster/--> <topicref href="devplatform/helion/admin/cluster/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/cluster/autoscaling/--> <topicref href="devplatform/helion/admin/cluster/1.1autoscaling.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/cluster/cloud-init/--> <topicref href="devplatform/helion/admin/cluster/1.1cloud-init.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/cluster/external-db/--> <topicref href="devplatform/helion/admin/cluster/1.1external-db.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/cluster/harbor/--> <topicref href="devplatform/helion/admin/cluster/1.1harbor.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/console/--> <topicref href="devplatform/helion/admin/console/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/console/app-store/--> <topicref href="devplatform/helion/admin/console/1.1app-store.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/console/customize/--> <topicref href="devplatform/helion/admin/console/1.1customize.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/reference/add-service/--> <topicref href="devplatform/helion/admin/reference/1.1add-service.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/reference/architecture/--> <topicref href="devplatform/helion/admin/reference/1.1architecture.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/reference/groups/--> <topicref href="devplatform/helion/admin/reference/1.1groups.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/reference/kato-ref/--> <topicref href="devplatform/helion/admin/reference/1.1kato-ref.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/reference/known-issues/--> <topicref href="devplatform/helion/admin/reference/1.1known-issues.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/reference/troubleshoot/--> <topicref href="devplatform/helion/admin/reference/1.1troubleshoot.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/server/--> <topicref href="devplatform/helion/admin/server/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/server/aok/--> <topicref href="devplatform/helion/admin/server/1.1aok.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/server/configuration/--> <topicref href="devplatform/helion/admin/server/1.1configuration.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/server/docker/--> <topicref href="devplatform/helion/admin/server/1.1docker.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/server/logging/--> <topicref href="devplatform/helion/admin/server/1.1logging.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/server/operations/--> <topicref href="devplatform/helion/admin/server/1.1operations.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/server/router/--> <topicref href="devplatform/helion/admin/server/1.1router.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/admin/server/upgrade/--> <topicref href="devplatform/helion/admin/server/1.1upgrade.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/--> <topicref href="devplatform/helion/user/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/client/--> <topicref href="devplatform/helion/user/client/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/console/--> <topicref href="devplatform/helion/user/console/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/--> <topicref href="devplatform/helion/user/deploy/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/app-debug/--> <topicref href="devplatform/helion/user/deploy/1.1app-debug.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/app-logs/--> <topicref href="devplatform/helion/user/deploy/1.1app-logs.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/buildpack/--> <topicref href="devplatform/helion/user/deploy/1.1buildpack.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/clojure/--> <topicref href="devplatform/helion/user/deploy/languages/1.1clojure.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/go/--> <topicref href="devplatform/helion/user/deploy/languages/1.1go.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/java/--> <topicref href="devplatform/helion/user/deploy/languages/1.1java.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/node/--> <topicref href="devplatform/helion/user/deploy/languages/1.1node.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/--> <topicref href="devplatform/helion/user/deploy/languages/perl/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/catalyst/--> <topicref href="devplatform/helion/user/deploy/languages/perl/1.1catalyst.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/cgiapppsgi/--> <topicref href="devplatform/helion/user/deploy/languages/perl/1.1cgiapppsgi.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/dancer/--> <topicref href="devplatform/helion/user/deploy/languages/perl/1.1dancer.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/mason/--> <topicref href="devplatform/helion/user/deploy/languages/perl/1.1mason.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/mojo/--> <topicref href="devplatform/helion/user/deploy/languages/perl/1.1mojo.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/perlcgi/--> <topicref href="devplatform/helion/user/deploy/languages/perl/1.1perlcgi.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/php/--> <topicref href="devplatform/helion/user/deploy/languages/1.1php.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/python/--> <topicref href="devplatform/helion/user/deploy/languages/python/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/python/django/--> <topicref href="devplatform/helion/user/deploy/languages/python/1.1django.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/ruby/--> <topicref href="devplatform/helion/user/deploy/languages/1.1ruby.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/manifestyml/--> <topicref href="devplatform/helion/user/deploy/1.1manifestyml.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/newrelic/--> <topicref href="devplatform/helion/user/deploy/1.1newrelic.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/orgs-spaces/--> <topicref href="devplatform/helion/user/deploy/1.1orgs-spaces.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/deploy/stackatoyml/--> <topicref href="devplatform/helion/user/deploy/1.1stackatoyml.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/quick-start/--> <topicref href="devplatform/helion/user/quick-start/1.1index.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/api/--> <topicref href="devplatform/helion/user/reference/1.1api.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/--> <topicref href="devplatform/helion/user/reference/1.1client-ref.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/administration/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-administration.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/applications/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-applications.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/brokers/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-brokers.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/buildpacks/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-buildpacks.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/control/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-control.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/domains/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-domains.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/flags/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-flags.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/gettingstarted/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-getting-started.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/history/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-history.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/information/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-information.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/management/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-management.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/miscellaneous/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-miscellaneous.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/organizations/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-organizations.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/placement/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-placement.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/quotas/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-quotas.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/routes/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-routes.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/securitygroups/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-securitygroups.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/servicemanagement/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-service-management.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/serviceplans/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-serviceplans.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/services/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-services.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/spacequotas/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-spacequotas.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/spaces/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-spaces.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/tokens/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-tokens.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/usermanagement/--> <topicref href="devplatform/helion/user/reference/1.1client-ref-user-management.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/environment/--> <topicref href="devplatform/helion/user/reference/1.1environment.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/glossary/--> <topicref href="devplatform/helion/user/reference/1.1glossary.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/reference/troubleshoot/--> <topicref href="devplatform/helion/user/reference/1.1troubleshoot.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/services/data-services/--> <topicref href="devplatform/helion/user/services/1.1data-services.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/services/filesystem/--> <topicref href="devplatform/helion/user/services/1.1filesystem.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/services/memcached/--> <topicref href="devplatform/helion/user/services/1.1memcached.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/services/port-service/--> <topicref href="devplatform/helion/user/services/1.1port-service.dita"/> 
- <!--permalink: /helion/devplatform/1.1/als/user/services/user-provided/--> <topicref href="devplatform/helion/user/services/1.1user-provided.dita"/> 
- <!--permalink: /helion/devplatform/1.1/appdev/--> <topicref href="devplatform/1.1devplatform.appdev.dita"/> 
- <!--permalink: /helion/devplatform/1.1/connectdatabase/--> <topicref href="devplatform/1.1devplatform.database-ALS.dita"/> 
- <!--permalink: /helion/devplatform/1.1/databaseservice/--> <topicref href="devplatform/1.1devplatform.database-instance.dita"/> 
- <!--permalink: /helion/devplatform/1.1/deploy/--> <topicref href="devplatform/1.1devplatform.deploy-ALS.dita"/> 
- <!--permalink: /helion/devplatform/1.1/eclipse/--> <topicref href="devplatform/1.1devplatform.eclipse.dita"/> 
- <!--permalink: /helion/devplatform/1.1/eula/--> <topicref href="devplatform/1.1devplatform.eula.dita"/> 
- <!--permalink: /helion/devplatform/1.1/install/troubleshooting/--> <topicref href="devplatform/1.1devplatform.troubleshooting.dita"/> 
- <!--permalink: /helion/devplatform/1.1/marketplace/--> <topicref href="devplatform/1.1devplatform.marketplace.install.dita"/> 
- <!--permalink: /helion/devplatform/1.1/messageservice/--> <topicref href="devplatform/1.1devplatform.using-the-messaging-service.dita"/> 
- <!--permalink: /helion/devplatform/1.1/msgaas/als/--> <topicref href="devplatform/1.1devplatform.using-messaging-service-with-ALS.dita"/> 
- <!--permalink: /helion/devplatform/1.1/related-topics/--> <topicref href="devplatform/1.1devplatform.related-topics.dita"/> 
- <!--permalink: /helion/devplatform/1.1/release-notes/--> <topicref href="devplatform/1.1devplatform.release-notes.dita"/> 
- <!--permalink: /helion/devplatform/1.1/sysadmin/--> <topicref href="devplatform/1.1devplatform.sysadmin.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/database/java/--> <topicref href="devplatform/workbook/database/1.1database.java.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/database/node/--> <topicref href="devplatform/workbook/database/1.1database.node.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/database/php/--> <topicref href="devplatform/workbook/database/1.1database.php.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/helloworld/java/--> <topicref href="devplatform/workbook/helloworld/1.1helloworld.java.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/helloworld/node/--> <topicref href="devplatform/workbook/helloworld/1.1helloworld.node.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/helloworld/php/--> <topicref href="devplatform/workbook/helloworld/1.1helloworld.php.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/messaging/java/--> <topicref href="devplatform/workbook/messaging/1.1messaging.java.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/messaging/node/--> <topicref href="devplatform/workbook/messaging/1.1messaging.node.dita"/> 
- <!--permalink: /helion/devplatform/1.1/workbook/messaging/php/--> <topicref href="devplatform/workbook/messaging/1.1messaging.php.dita"/> 
- <!--permalink: /helion/devplatform/1.2/--> <topicref href="devplatform/1.2/1.2devplatform.index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/3rd-party-license-agreements/--> <topicref href="devplatform/1.2/1.2devplatform.thirdparty.licensing.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/--> <topicref href="devplatform/1.2/helion/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/--> <topicref href="devplatform/1.2/helion/admin/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/best-practices/--> <topicref href="devplatform/1.2/helion/admin/best-practices/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/best-practices/logging-examples/--> <topicref href="devplatform/1.2/helion/admin/best-practices/1.2logging-examples.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/cluster/--> <topicref href="devplatform/1.2/helion/admin/cluster/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/cluster/autoscaling/--> <topicref href="devplatform/1.2/helion/admin/cluster/1.2autoscaling.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/cluster/cloud-init/--> <topicref href="devplatform/1.2/helion/admin/cluster/1.2cloud-init.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/cluster/external-db/--> <topicref href="devplatform/1.2/helion/admin/cluster/1.2external-db.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/cluster/harbor/--> <topicref href="devplatform/1.2/helion/admin/cluster/1.2harbor.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/console/--> <topicref href="devplatform/1.2/helion/admin/console/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/console/app-store/--> <topicref href="devplatform/1.2/helion/admin/console/1.2app-store.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/console/customize/--> <topicref href="devplatform/1.2/helion/admin/console/1.2customize.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/reference/add-service/--> <topicref href="devplatform/1.2/helion/admin/reference/1.2add-service.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/reference/architecture/--> <topicref href="devplatform/1.2/helion/admin/reference/1.2architecture.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/reference/groups/--> <topicref href="devplatform/1.2/helion/admin/reference/1.2groups.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/reference/kato-ref/--> <topicref href="devplatform/1.2/helion/admin/reference/1.2kato-ref.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/reference/known-issues/--> <topicref href="devplatform/1.2/helion/admin/reference/1.2known-issues.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/reference/troubleshoot/--> <topicref href="devplatform/1.2/helion/admin/reference/1.2troubleshoot.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/server/--> <topicref href="devplatform/1.2/helion/admin/server/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/server/aok/--> <topicref href="devplatform/1.2/helion/admin/server/1.2aok.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/server/configuration/--> <topicref href="devplatform/1.2/helion/admin/server/1.2configuration.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/server/docker/--> <topicref href="devplatform/1.2/helion/admin/server/1.2docker.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/server/logging/--> <topicref href="devplatform/1.2/helion/admin/server/1.2logging.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/server/operations/--> <topicref href="devplatform/1.2/helion/admin/server/1.2operations.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/server/router/--> <topicref href="devplatform/1.2/helion/admin/server/1.2router.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/admin/server/upgrade/--> <topicref href="devplatform/1.2/helion/admin/server/1.2upgrade.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/--> <topicref href="devplatform/1.2/helion/user/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/client/--> <topicref href="devplatform/1.2/helion/user/client/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/console/--> <topicref href="devplatform/1.2/helion/user/console/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/app-debug/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2app-debug.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/app-logs/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2app-logs.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/buildpack/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2buildpack.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/clojure/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2clojure.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/go/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2go.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/java/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2java.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/node/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2node.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/catalyst/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2catalyst.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/cgiapppsgi/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2cgiapppsgi.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/dancer/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2dancer.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/mason/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2mason.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/mojo/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2mojo.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/perlcgi/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2perlcgi.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/php/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2php.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/python/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/python/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/python/django/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/python/1.2django.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/ruby/--> <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2ruby.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/manifestyml/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2manifestyml.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/newrelic/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2newrelic.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/orgs-spaces/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2orgs-spaces.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/other-frameworks/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2other-frameworks.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/deploy/stackatoyml/--> <topicref href="devplatform/1.2/helion/user/deploy/1.2stackatoyml.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/quick-start/--> <topicref href="devplatform/1.2/helion/user/quick-start/1.2index.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/api/--> <topicref href="devplatform/1.2/helion/user/reference/1.2api.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/administration/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-administration.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/applications/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-applications.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/brokers/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-brokers.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/buildpacks/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-buildpacks.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/control/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-control.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/domains/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-domains.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/flags/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-flags.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/gettingstarted/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-getting-started.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/history/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-history.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/information/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-information.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/management/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-management.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/miscellaneous/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-miscellaneous.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/organizations/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-organizations.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/placement/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-placement.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/quotas/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-quotas.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/routes/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-routes.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/securitygroups/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-securitygroups.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/servicemanagement/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-service-management.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/serviceplans/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-serviceplans.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/services/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-services.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/spacequotas/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-spacequotas.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/spaces/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-spaces.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/tokens/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-tokens.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/usermanagement/--> <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-user-management.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/environment/--> <topicref href="devplatform/1.2/helion/user/reference/1.2environment.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/glossary/--> <topicref href="devplatform/1.2/helion/user/reference/1.2glossary.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/reference/troubleshoot/--> <topicref href="devplatform/1.2/helion/user/reference/1.2troubleshoot.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/services/data-services/--> <topicref href="devplatform/1.2/helion/user/services/1.2data-services.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/services/filesystem/--> <topicref href="devplatform/1.2/helion/user/services/1.2filesystem.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/services/memcached/--> <topicref href="devplatform/1.2/helion/user/services/1.2memcached.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/services/port-service/--> <topicref href="devplatform/1.2/helion/user/services/1.2port-service.dita"/> 
- <!--permalink: /helion/devplatform/1.2/als/user/services/user-provided/--> <topicref href="devplatform/1.2/helion/user/services/1.2user-provided.dita"/> 
- <!--permalink: /helion/devplatform/1.2/appdev/--> <topicref href="devplatform/1.2/1.2devplatform.appdev.dita"/> 
- <!--permalink: /helion/devplatform/1.2/connectdatabase/--> <topicref href="devplatform/1.2/1.2devplatform.database-ALS.dita"/> 
- <!--permalink: /helion/devplatform/1.2/databaseservice/--> <topicref href="devplatform/1.2/1.2devplatform.database-instance.dita"/> 
- <!--permalink: /helion/devplatform/1.2/deploy/--> <topicref href="devplatform/1.2/1.2devplatform.deploy-ALS.dita"/> 
- <!--permalink: /helion/devplatform/1.2/eclipse/--> <topicref href="devplatform/1.2/1.2devplatform.eclipse.dita"/> 
- <!--permalink: /helion/devplatform/1.2/eula/--> <topicref href="devplatform/1.2/1.2devplatform.eula.dita"/> 
- <!--permalink: /helion/devplatform/1.2/horizonuiinstallation/--> <topicref href="devplatform/1.2/1.2devplatform.horizonui.install.dita"/> 
- <!--permalink: /helion/devplatform/1.2/install/--> <topicref href="devplatform/1.2/1.2devplatform_commercial_install.dita"/> 
- <!--permalink: /helion/devplatform/1.2/install/community/--> <topicref href="devplatform/1.2/1.2devplatform_community_install.dita"/> 
- <!--permalink: /helion/devplatform/1.2/install/troubleshooting/--> <topicref href="devplatform/1.2/1.2devplatform.troubleshooting.dita"/> 
- <!--permalink: /helion/devplatform/1.2/marketplace/--> <topicref href="devplatform/1.2/1.2devplatform.marketplace.install.dita"/> 
- <!--permalink: /helion/devplatform/1.2/messageservice/--> <topicref href="devplatform/1.2/1.2devplatform.using-the-messaging-service.dita"/> 
- <!--permalink: /helion/devplatform/1.2/msgaas/als/--> <topicref href="devplatform/1.2/1.2devplatform.using-messaging-service-with-ALS.dita"/> 
- <!--permalink: /helion/devplatform/1.2/related-topics/--> <topicref href="devplatform/1.2/1.2devplatform.related-topics.dita"/> 
- <!--permalink: /helion/devplatform/1.2/release-notes/--> <topicref href="devplatform/1.2/1.2devplatform.release-notes.dita"/> 
- <!--permalink: /helion/devplatform/1.2/sysadmin/--> <topicref href="devplatform/1.2/1.2devplatform.sysadmin.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/database/java/--> <topicref href="devplatform/1.2/workbook/database/1.2database.java.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/database/node/--> <topicref href="devplatform/1.2/workbook/database/1.2database.node.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/database/php/--> <topicref href="devplatform/1.2/workbook/database/1.2database.php.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/helloworld/java/--> <topicref href="devplatform/1.2/workbook/helloworld/1.2helloworld.java.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/helloworld/node/--> <topicref href="devplatform/1.2/workbook/helloworld/1.2helloworld.node.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/helloworld/php/--> <topicref href="devplatform/1.2/workbook/helloworld/1.2helloworld.php.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/messaging/java/--> <topicref href="devplatform/1.2/workbook/messaging/1.2messaging.java.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/messaging/node/--> <topicref href="devplatform/1.2/workbook/messaging/1.2messaging.node.dita"/> 
- <!--permalink: /helion/devplatform/1.2/workbook/messaging/php/--> <topicref href="devplatform/1.2/workbook/messaging/1.2messaging.php.dita"/> 
+ <!--permalink: /helion/devplatform/1.1/--> <topicref href="devplatform/1.1devplatform.index.dita">
+  <topicref href="devplatform/helion/1.1index.dita"/>
+  <topicref href="devplatform/helion/admin/1.1index.dita"/>
+  <topicref href="devplatform/helion/admin/best-practices/1.1index.dita"/>
+  <topicref href="devplatform/helion/admin/best-practices/1.1logging-examples.dita"/>
+  <topicref href="devplatform/helion/admin/cluster/1.1index.dita"/>
+  <topicref href="devplatform/helion/admin/cluster/1.1autoscaling.dita"/>
+  <topicref href="devplatform/helion/admin/cluster/1.1cloud-init.dita"/>
+  <topicref href="devplatform/helion/admin/cluster/1.1external-db.dita"/>
+  <topicref href="devplatform/helion/admin/cluster/1.1harbor.dita"/>
+  <topicref href="devplatform/helion/admin/console/1.1index.dita"/>
+  <topicref href="devplatform/helion/admin/console/1.1app-store.dita"/>
+  <topicref href="devplatform/helion/admin/console/1.1customize.dita"/>
+  <topicref href="devplatform/helion/admin/reference/1.1add-service.dita"/>
+  <topicref href="devplatform/helion/admin/reference/1.1architecture.dita"/>
+  <topicref href="devplatform/helion/admin/reference/1.1groups.dita"/>
+  <topicref href="devplatform/helion/admin/reference/1.1kato-ref.dita"/>
+  <topicref href="devplatform/helion/admin/reference/1.1known-issues.dita"/>
+  <topicref href="devplatform/helion/admin/reference/1.1troubleshoot.dita"/>
+  <topicref href="devplatform/helion/admin/server/1.1index.dita"/>
+  <topicref href="devplatform/helion/admin/server/1.1aok.dita"/>
+  <topicref href="devplatform/helion/admin/server/1.1configuration.dita"/>
+  <topicref href="devplatform/helion/admin/server/1.1docker.dita"/>
+  <topicref href="devplatform/helion/admin/server/1.1logging.dita"/>
+  <topicref href="devplatform/helion/admin/server/1.1operations.dita"/>
+  <topicref href="devplatform/helion/admin/server/1.1router.dita"/>
+  <topicref href="devplatform/helion/admin/server/1.1upgrade.dita"/>
+  <topicref href="devplatform/helion/user/1.1index.dita"/>
+  <topicref href="devplatform/helion/user/client/1.1index.dita"/>
+  <topicref href="devplatform/helion/user/console/1.1index.dita"/>
+  <topicref href="devplatform/helion/user/deploy/1.1index.dita"/>
+  <topicref href="devplatform/helion/user/deploy/1.1app-debug.dita"/>
+  <topicref href="devplatform/helion/user/deploy/1.1app-logs.dita"/>
+  <topicref href="devplatform/helion/user/deploy/1.1buildpack.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/1.1clojure.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/1.1go.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/1.1java.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/1.1node.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/perl/1.1index.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/perl/1.1catalyst.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/perl/1.1cgiapppsgi.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/perl/1.1dancer.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/perl/1.1mason.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/perl/1.1mojo.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/perl/1.1perlcgi.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/1.1php.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/python/1.1index.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/python/1.1django.dita"/>
+  <topicref href="devplatform/helion/user/deploy/languages/1.1ruby.dita"/>
+  <topicref href="devplatform/helion/user/deploy/1.1manifestyml.dita"/>
+  <topicref href="devplatform/helion/user/deploy/1.1newrelic.dita"/>
+  <topicref href="devplatform/helion/user/deploy/1.1orgs-spaces.dita"/>
+  <topicref href="devplatform/helion/user/deploy/1.1stackatoyml.dita"/>
+  <topicref href="devplatform/helion/user/quick-start/1.1index.dita"/>
+  <topicref href="devplatform/helion/user/reference/1.1api.dita"/>
+  <topicref href="devplatform/helion/user/reference/1.1client-ref.dita">
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-administration.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-applications.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-brokers.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-buildpacks.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-control.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-domains.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-flags.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-getting-started.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-history.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-information.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-management.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-miscellaneous.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-organizations.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-placement.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-quotas.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-routes.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-securitygroups.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-service-management.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-serviceplans.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-services.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-spacequotas.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-spaces.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-tokens.dita"/>
+   <topicref href="devplatform/helion/user/reference/1.1client-ref-user-management.dita"/>
+  </topicref>
+  <topicref href="devplatform/helion/user/reference/1.1environment.dita"/>
+  <topicref href="devplatform/helion/user/reference/1.1glossary.dita"/>
+  <topicref href="devplatform/helion/user/reference/1.1troubleshoot.dita"/>
+  <topicref href="devplatform/helion/user/services/1.1data-services.dita"/>
+  <topicref href="devplatform/helion/user/services/1.1filesystem.dita"/>
+  <topicref href="devplatform/helion/user/services/1.1memcached.dita"/>
+  <topicref href="devplatform/helion/user/services/1.1port-service.dita"/>
+  <topicref href="devplatform/helion/user/services/1.1user-provided.dita"/>
+  <topicref href="devplatform/1.1devplatform.appdev.dita"/>
+  <topicref href="devplatform/1.1devplatform.database-ALS.dita"/>
+  <topicref href="devplatform/1.1devplatform.database-instance.dita"/>
+  <topicref href="devplatform/1.1devplatform.deploy-ALS.dita"/>
+  <topicref href="devplatform/1.1devplatform.eclipse.dita"/>
+  <topicref href="devplatform/1.1devplatform.eula.dita"/>
+  <topicref href="devplatform/1.1devplatform.troubleshooting.dita"/>
+  <topicref href="devplatform/1.1devplatform.marketplace.install.dita"/>
+  <topicref href="devplatform/1.1devplatform.using-the-messaging-service.dita"/>
+  <topicref href="devplatform/1.1devplatform.using-messaging-service-with-ALS.dita"/>
+  <topicref href="devplatform/1.1devplatform.related-topics.dita"/>
+  <topicref href="devplatform/1.1devplatform.release-notes.dita"/>
+  <topicref href="devplatform/1.1devplatform.sysadmin.dita"/>
+  <topicref href="devplatform/workbook/database/1.1database.java.dita"/>
+  <topicref href="devplatform/workbook/database/1.1database.node.dita"/>
+  <topicref href="devplatform/workbook/database/1.1database.php.dita"/>
+  <topicref href="devplatform/workbook/helloworld/1.1helloworld.java.dita"/>
+  <topicref href="devplatform/workbook/helloworld/1.1helloworld.node.dita"/>
+  <topicref href="devplatform/workbook/helloworld/1.1helloworld.php.dita"/>
+  <topicref href="devplatform/workbook/messaging/1.1messaging.java.dita"/>
+  <topicref href="devplatform/workbook/messaging/1.1messaging.node.dita"/>
+  <topicref href="devplatform/workbook/messaging/1.1messaging.php.dita"/>
+  <topicref href="devplatform/1.1devplatform.thirdparty.licensing.dita"/>
+ </topicref> 
+ <!--permalink: /helion/devplatform/1.1/3rd-party-license-agreements/--> 
+ <!--permalink: /helion/devplatform/1.1/als/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/best-practices/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/best-practices/logging-examples/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/cluster/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/cluster/autoscaling/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/cluster/cloud-init/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/cluster/external-db/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/cluster/harbor/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/console/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/console/app-store/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/console/customize/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/reference/add-service/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/reference/architecture/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/reference/groups/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/reference/kato-ref/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/reference/known-issues/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/reference/troubleshoot/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/server/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/server/aok/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/server/configuration/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/server/docker/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/server/logging/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/server/operations/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/server/router/--> 
+ <!--permalink: /helion/devplatform/1.1/als/admin/server/upgrade/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/client/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/console/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/app-debug/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/app-logs/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/buildpack/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/clojure/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/go/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/java/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/node/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/catalyst/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/cgiapppsgi/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/dancer/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/mason/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/mojo/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/perl/perlcgi/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/php/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/python/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/python/django/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/languages/ruby/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/manifestyml/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/newrelic/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/orgs-spaces/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/deploy/stackatoyml/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/quick-start/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/api/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/administration/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/applications/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/brokers/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/buildpacks/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/control/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/domains/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/flags/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/gettingstarted/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/history/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/information/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/management/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/miscellaneous/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/organizations/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/placement/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/quotas/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/routes/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/securitygroups/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/servicemanagement/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/serviceplans/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/services/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/spacequotas/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/spaces/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/tokens/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/client-ref/usermanagement/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/environment/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/glossary/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/reference/troubleshoot/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/services/data-services/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/services/filesystem/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/services/memcached/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/services/port-service/--> 
+ <!--permalink: /helion/devplatform/1.1/als/user/services/user-provided/--> 
+ <!--permalink: /helion/devplatform/1.1/appdev/--> 
+ <!--permalink: /helion/devplatform/1.1/connectdatabase/--> 
+ <!--permalink: /helion/devplatform/1.1/databaseservice/--> 
+ <!--permalink: /helion/devplatform/1.1/deploy/--> 
+ <!--permalink: /helion/devplatform/1.1/eclipse/--> 
+ <!--permalink: /helion/devplatform/1.1/eula/--> 
+ <!--permalink: /helion/devplatform/1.1/install/troubleshooting/--> 
+ <!--permalink: /helion/devplatform/1.1/marketplace/--> 
+ <!--permalink: /helion/devplatform/1.1/messageservice/--> 
+ <!--permalink: /helion/devplatform/1.1/msgaas/als/--> 
+ <!--permalink: /helion/devplatform/1.1/related-topics/--> 
+ <!--permalink: /helion/devplatform/1.1/release-notes/--> 
+ <!--permalink: /helion/devplatform/1.1/sysadmin/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/database/java/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/database/node/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/database/php/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/helloworld/java/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/helloworld/node/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/helloworld/php/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/messaging/java/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/messaging/node/--> 
+ <!--permalink: /helion/devplatform/1.1/workbook/messaging/php/--> 
+ <!--permalink: /helion/devplatform/1.2/--> <topicref href="devplatform/1.2/1.2devplatform.index.dita">
+  <topicref href="devplatform/1.2/1.2devplatform.thirdparty.licensing.dita"/>
+  <topicref href="devplatform/1.2/helion/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/best-practices/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/best-practices/1.2logging-examples.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/cluster/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/cluster/1.2autoscaling.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/cluster/1.2cloud-init.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/cluster/1.2external-db.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/cluster/1.2harbor.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/console/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/console/1.2app-store.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/console/1.2customize.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/reference/1.2add-service.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/reference/1.2architecture.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/reference/1.2groups.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/reference/1.2kato-ref.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/reference/1.2known-issues.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/reference/1.2troubleshoot.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/server/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/server/1.2aok.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/server/1.2configuration.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/server/1.2docker.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/server/1.2logging.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/server/1.2operations.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/server/1.2router.dita"/>
+  <topicref href="devplatform/1.2/helion/admin/server/1.2upgrade.dita"/>
+  <topicref href="devplatform/1.2/helion/user/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/user/client/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/user/console/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2app-debug.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2app-logs.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2buildpack.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2clojure.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2go.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2java.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2node.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2catalyst.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2cgiapppsgi.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2dancer.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2mason.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2mojo.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/perl/1.2perlcgi.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2php.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/python/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/python/1.2django.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/languages/1.2ruby.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2manifestyml.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2newrelic.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2orgs-spaces.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2other-frameworks.dita"/>
+  <topicref href="devplatform/1.2/helion/user/deploy/1.2stackatoyml.dita"/>
+  <topicref href="devplatform/1.2/helion/user/quick-start/1.2index.dita"/>
+  <topicref href="devplatform/1.2/helion/user/reference/1.2api.dita"/>
+  <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref.dita">
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-administration.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-applications.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-brokers.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-buildpacks.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-control.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-domains.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-flags.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-getting-started.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-history.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-information.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-management.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-miscellaneous.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-organizations.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-placement.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-quotas.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-routes.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-securitygroups.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-service-management.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-serviceplans.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-services.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-spacequotas.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-spaces.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-tokens.dita"/>
+   <topicref href="devplatform/1.2/helion/user/reference/1.2client-ref-user-management.dita"/>
+  </topicref>
+  <topicref href="devplatform/1.2/helion/user/reference/1.2environment.dita"/>
+  <topicref href="devplatform/1.2/helion/user/reference/1.2glossary.dita"/>
+  <topicref href="devplatform/1.2/helion/user/reference/1.2troubleshoot.dita"/>
+  <topicref href="devplatform/1.2/helion/user/services/1.2data-services.dita"/>
+  <topicref href="devplatform/1.2/helion/user/services/1.2filesystem.dita"/>
+  <topicref href="devplatform/1.2/helion/user/services/1.2memcached.dita"/>
+  <topicref href="devplatform/1.2/helion/user/services/1.2port-service.dita"/>
+  <topicref href="devplatform/1.2/helion/user/services/1.2user-provided.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.appdev.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.database-ALS.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.database-instance.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.deploy-ALS.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.eclipse.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.eula.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.horizonui.install.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform_commercial_install.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform_community_install.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.troubleshooting.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.marketplace.install.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.using-the-messaging-service.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.using-messaging-service-with-ALS.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.related-topics.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.release-notes.dita"/>
+  <topicref href="devplatform/1.2/1.2devplatform.sysadmin.dita"/>
+  <topicref href="devplatform/1.2/workbook/database/1.2database.java.dita"/>
+  <topicref href="devplatform/1.2/workbook/database/1.2database.node.dita"/>
+  <topicref href="devplatform/1.2/workbook/database/1.2database.php.dita"/>
+  <topicref href="devplatform/1.2/workbook/helloworld/1.2helloworld.java.dita"/>
+  <topicref href="devplatform/1.2/workbook/helloworld/1.2helloworld.node.dita"/>
+  <topicref href="devplatform/1.2/workbook/helloworld/1.2helloworld.php.dita"/>
+  <topicref href="devplatform/1.2/workbook/messaging/1.2messaging.java.dita"/>
+  <topicref href="devplatform/1.2/workbook/messaging/1.2messaging.node.dita"/>
+  <topicref href="devplatform/1.2/workbook/messaging/1.2messaging.php.dita"/>
+ </topicref> 
+ <!--permalink: /helion/devplatform/1.2/3rd-party-license-agreements/--> 
+ <!--permalink: /helion/devplatform/1.2/als/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/best-practices/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/best-practices/logging-examples/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/cluster/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/cluster/autoscaling/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/cluster/cloud-init/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/cluster/external-db/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/cluster/harbor/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/console/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/console/app-store/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/console/customize/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/reference/add-service/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/reference/architecture/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/reference/groups/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/reference/kato-ref/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/reference/known-issues/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/reference/troubleshoot/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/server/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/server/aok/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/server/configuration/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/server/docker/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/server/logging/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/server/operations/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/server/router/--> 
+ <!--permalink: /helion/devplatform/1.2/als/admin/server/upgrade/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/client/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/console/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/app-debug/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/app-logs/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/buildpack/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/clojure/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/go/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/java/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/node/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/catalyst/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/cgiapppsgi/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/dancer/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/mason/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/mojo/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/perl/perlcgi/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/php/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/python/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/python/django/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/languages/ruby/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/manifestyml/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/newrelic/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/orgs-spaces/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/other-frameworks/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/deploy/stackatoyml/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/quick-start/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/api/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/administration/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/applications/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/brokers/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/buildpacks/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/control/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/domains/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/flags/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/gettingstarted/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/history/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/information/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/management/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/miscellaneous/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/organizations/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/placement/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/quotas/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/routes/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/securitygroups/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/servicemanagement/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/serviceplans/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/services/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/spacequotas/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/spaces/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/tokens/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/client-ref/usermanagement/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/environment/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/glossary/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/reference/troubleshoot/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/services/data-services/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/services/filesystem/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/services/memcached/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/services/port-service/--> 
+ <!--permalink: /helion/devplatform/1.2/als/user/services/user-provided/--> 
+ <!--permalink: /helion/devplatform/1.2/appdev/--> 
+ <!--permalink: /helion/devplatform/1.2/connectdatabase/--> 
+ <!--permalink: /helion/devplatform/1.2/databaseservice/--> 
+ <!--permalink: /helion/devplatform/1.2/deploy/--> 
+ <!--permalink: /helion/devplatform/1.2/eclipse/--> 
+ <!--permalink: /helion/devplatform/1.2/eula/--> 
+ <!--permalink: /helion/devplatform/1.2/horizonuiinstallation/--> 
+ <!--permalink: /helion/devplatform/1.2/install/--> 
+ <!--permalink: /helion/devplatform/1.2/install/community/--> 
+ <!--permalink: /helion/devplatform/1.2/install/troubleshooting/--> 
+ <!--permalink: /helion/devplatform/1.2/marketplace/--> 
+ <!--permalink: /helion/devplatform/1.2/messageservice/--> 
+ <!--permalink: /helion/devplatform/1.2/msgaas/als/--> 
+ <!--permalink: /helion/devplatform/1.2/related-topics/--> 
+ <!--permalink: /helion/devplatform/1.2/release-notes/--> 
+ <!--permalink: /helion/devplatform/1.2/sysadmin/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/database/java/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/database/node/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/database/php/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/helloworld/java/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/helloworld/node/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/helloworld/php/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/messaging/java/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/messaging/node/--> 
+ <!--permalink: /helion/devplatform/1.2/workbook/messaging/php/--> 
  <!--permalink: /helion/devplatform/3rd-party-license-agreements/--> <topicref href="devplatform/1.0devplatform.thirdparty.licensing.dita"/> 
  <!--permalink: /helion/devplatform/appdev/--> <topicref href="devplatform/1.0devplatform.appdev.dita"/> 
  <!--permalink: /helion/devplatform/connectdatabase/--> <topicref href="devplatform/1.0devplatform.database-ALS.dita"/> 


### PR DESCRIPTION
Putting ALS documentation under its heading; putting all 1.1 and 1.2 docs under their respective index page